### PR TITLE
[Docs/openapi-swagger] API 문서 생성 자동화를 위한 OpenAPI3 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import groovy.json.JsonSlurper
+import groovy.json.JsonOutput
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.4'
@@ -5,6 +8,9 @@ plugins {
 
     // spring rest docs 관련
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+
+    // rest docs api spec
+    id 'com.epages.restdocs-api-spec' version '0.18.2'
 }
 
 group = 'me.jooeon'
@@ -70,6 +76,12 @@ dependencies {
     // thumbnailator
     implementation 'net.coobird:thumbnailator:0.4.20'
 
+    // rest docs api spec
+    testImplementation('com.epages:restdocs-api-spec-mockmvc:0.18.2')
+    testImplementation('com.epages:restdocs-api-spec:0.18.2')
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {
@@ -109,5 +121,64 @@ bootJar {
     }
     from("${asciidoctor.outputDir}") {
         into 'static/docs'
+    }
+}
+
+openapi3 {
+    server = 'http://localhost:8080'
+    title = 'My API'
+    description = 'My API description'
+    version = '0.1.0'
+    format = 'json'
+
+    copy {
+        from "build/api-spec"
+        into "src/main/resources/static/docs/"
+    }
+}
+
+task injectSecurityDefinition {
+    doLast {
+        def outputFile = file("build/api-spec/openapi3.json")
+        if (outputFile.exists()) {
+            def json = new JsonSlurper().parseText(outputFile.text)
+            // components가 없으면 생성
+            json.components = json.components ?: [:]
+            // securitySchemes가 없으면 생성
+            json.components.securitySchemes = json.components.securitySchemes ?: [:]
+            // JWT 보안 스키마 추가
+            json.components.securitySchemes.BearerAuth = [
+                    type         : "http",
+                    scheme       : "bearer",
+                    bearerFormat : "JWT"
+            ]
+            // 전역 security 설정 추가
+            json.security = [[ "BearerAuth": [] ]]
+
+            // JSON 포맷 재설정 후 저장
+            outputFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(json))
+            println "Security definition injected into openapi3.json"
+        } else {
+            println "openapi3.json not found at: ${outputFile.absolutePath}"
+        }
+    }
+}
+
+// openapi3 태스크가 끝난 후에 injectSecurityDefinition 태스크 실행
+afterEvaluate {
+    tasks.named("openapi3").configure {
+        finalizedBy injectSecurityDefinition
+    }
+}
+
+afterEvaluate {
+    // 빌드 실행 openaapi3 테스크가 자동 실해되도록 설정
+    tasks.named("build") {
+        dependsOn tasks.named("openapi3")
+    }
+
+    // bootJar 실행 시 openapi3가 실행되도록 설정 (실행 가능한 JAR에 포함)
+    tasks.named("bootJar") {
+        dependsOn tasks.named("openapi3")
     }
 }

--- a/src/main/java/me/jooeon/mybeauty/global/common/config/OpenApiConfig.java
+++ b/src/main/java/me/jooeon/mybeauty/global/common/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package me.jooeon.mybeauty.global.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(
+                        new Components()
+                                .addSchemas(
+                                        "BaseResponseSchema",
+                                        new Schema<>()
+                                                .addProperty("isSuccess", new BooleanSchema().description("API 성공 여부")
+                                                .addProperty("responseCode", new IntegerSchema().description("응답 코드")))
+                                                .addProperty("responseMessage", new StringSchema().description("응답 메시지"))
+                                                .addProperty("result", new Schema<>().description("응답 결과(API 별로 다른 값)")).nullable(true))
+                );
+    }
+}

--- a/src/main/java/me/jooeon/mybeauty/global/common/config/SecurityConfig.java
+++ b/src/main/java/me/jooeon/mybeauty/global/common/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package me.jooeon.mybeauty.global.common.security;
+package me.jooeon.mybeauty.global.common.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +8,8 @@ import me.jooeon.mybeauty.domain.auth.utils.JwtUtil;
 import me.jooeon.mybeauty.domain.auth.presentation.handler.CustomAuthenticationSuccessHandler;
 import me.jooeon.mybeauty.domain.member.model.Role;
 import me.jooeon.mybeauty.global.common.exception.handler.FilterExceptionHandler;
+import me.jooeon.mybeauty.global.common.security.CustomAccessDeniedHandler;
+import me.jooeon.mybeauty.global.common.security.CustomAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -55,7 +57,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/api-json/**", "/api-docs", "/swagger-ui/**", "/swagger-resources/**").permitAll()
-                        .requestMatchers("/oauth2/**","/login/**", "/reissue", "/api/login/success", "/docs/**", "/app/api/image/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/oauth2/**","/login/**", "/reissue", "/api/login/success", "/docs/**", "/app/api/image/**", "/swagger-ui", "/swagger-ui/**", "/v3/**").permitAll()
                         //.anyRequest().authenticated() // 이상함
                         .anyRequest().hasRole(Role.MEMBER.getValue())
                 );

--- a/src/main/java/me/jooeon/mybeauty/global/common/config/SecurityConfig.java
+++ b/src/main/java/me/jooeon/mybeauty/global/common/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/", "/api-json/**", "/api-docs", "/swagger-ui/**", "/swagger-resources/**").permitAll()
-                        .requestMatchers("/oauth2/**","/login/**", "/reissue", "/api/login/success", "/docs/**", "/app/api/image/**").permitAll()
+                        .requestMatchers("/oauth2/**","/login/**", "/reissue", "/api/login/success", "/docs/**", "/app/api/image/**", "/swagger-ui/**").permitAll()
                         //.anyRequest().authenticated() // 이상함
                         .anyRequest().hasRole(Role.MEMBER.getValue())
                 );

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,3 +51,16 @@ logging:
 # aws s3 설정 추가 예정
 
 # Spring Docs 설정 <- Spring Rest Docs 사용할 것인지 Open API를 용한 Swagger 사용할 것인지 고민 후 추가 필요
+
+# Swagger 설정
+springdoc:
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui  # Swagger UI의 기본 URL 설정
+    url: /docs/openapi3.json  # 기본적으로 로드할 OpenAPI 문서 경로 설정
+    display-request-duration: true  # 요청 소요 시간 표시
+    deep-linking: true  # API 경로 링크를 직접 클릭 가능하게 함
+  api-docs:
+    enabled: true
+    path: /hidden-api-docs # 기본 /v3/api-docs 경로 숨김
+

--- a/src/main/resources/static/docs/comment.html
+++ b/src/main/resources/static/docs/comment.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.18">
-<title>Coonect API Document</title>
+<title>Conect API Document</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -440,7 +440,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="book toc2 toc-left">
 <div id="header">
-<h1>Coonect API Document</h1>
+<h1>Conect API Document</h1>
 <div class="details">
 <span id="revnumber">version 0.0.1-SNAPSHOT</span>
 </div>
@@ -527,42 +527,9 @@ Content-Length: 123
 </div>
 <div class="sect3">
 <h4 id="_응답_필드">응답 필드</h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isSuccess</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">API 성공 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>responseCode</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>responseMessage</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>result</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">요청 결과 생성된 댓글 ID</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Unresolved directive in comment.adoc - include::/Users/ijueon/mydev/mybeauty/build/generated-snippets/comment-create/response-fields.adoc[]</p>
+</div>
 </div>
 </div>
 </div>
@@ -571,7 +538,7 @@ Content-Length: 123
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-02-14 15:49:25 +0900
+Last updated 2025-02-14 17:03:07 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/me/jooeon/mybeauty/api/comment/CommentControllerTest.java
+++ b/src/test/java/me/jooeon/mybeauty/api/comment/CommentControllerTest.java
@@ -1,24 +1,31 @@
 package me.jooeon.mybeauty.api.comment;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.models.OpenAPI;
 import me.jooeon.mybeauty.domain.article.application.CommentApplicationService;
 import me.jooeon.mybeauty.domain.article.model.dto.article.CommentSaveRequestDto;
 import me.jooeon.mybeauty.domain.article.presentation.CommentController;
 import me.jooeon.mybeauty.global.CommonControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -48,13 +55,30 @@ public class CommentControllerTest extends CommonControllerTest {
         when(commentApplicationService.createComment(any(CommentSaveRequestDto.class), anyLong(), anyLong())).thenReturn(expectedCommentId);
 
         // when
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/app/api/articles/{articleId}/comments", testArticleId)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/app/api/articles/{articleId}/comments", testArticleId)
                 .header("Authorization", "Bearer your-bearer-token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(new ObjectMapper().writeValueAsString(requestDto)))
                 .andDo(print());
 
         // then
+//        result.andExpect(status().isOk())
+//                .andExpect(jsonPath("$.isSuccess").value(true))
+//                .andExpect(jsonPath("$.result").value(expectedCommentId))
+//                .andDo(document("comment-create",    // 문서 식별자
+//                        preprocessRequest(prettyPrint()),    // 요청 데이터 보기 좋게 출력
+//                        preprocessResponse(prettyPrint()),    // 응답 데이터 보기 좋게 출력
+//                        requestHeaders(    // 요청 헤더 문서화
+//                                headerWithName("Authorization").description("사용자 인증 및 인가를 위한 Bearer token")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("isSuccess").description("API 성공 여부"),
+//                                fieldWithPath("responseCode").description("응답 코드"),
+//                                fieldWithPath("responseMessage").description("응답 메시지"),
+//                                fieldWithPath("result").description("요청 결과 생성된 댓글 ID")
+//                        )
+//                ));
+
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.result").value(expectedCommentId))
@@ -64,11 +88,19 @@ public class CommentControllerTest extends CommonControllerTest {
                         requestHeaders(    // 요청 헤더 문서화
                                 headerWithName("Authorization").description("사용자 인증 및 인가를 위한 Bearer token")
                         ),
-                        responseFields(
-                                fieldWithPath("isSuccess").description("API 성공 여부"),
-                                fieldWithPath("responseCode").description("응답 코드"),
-                                fieldWithPath("responseMessage").description("응답 메시지"),
-                                fieldWithPath("result").description("요청 결과 생성된 댓글 ID")
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Comment API")
+                                        .summary("댓글 생성 API")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("Bearer 토큰 (예: `Bearer your-jwt-token`)")
+                                        )
+                                        .responseFields(
+                                            fieldWithPath("isSuccess").description("API 성공 여부"),
+                                            fieldWithPath("responseCode").description("응답 코드"),
+                                            fieldWithPath("responseMessage").description("응답 메시지"),
+                                            fieldWithPath("result").description("요청 결과 생성된 댓글 ID")
+                                        ).build()
                         )
                 ));
     }

--- a/src/test/java/me/jooeon/mybeauty/api/comment/CommentControllerTest.java
+++ b/src/test/java/me/jooeon/mybeauty/api/comment/CommentControllerTest.java
@@ -1,6 +1,7 @@
 package me.jooeon.mybeauty.api.comment;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.models.OpenAPI;
 import me.jooeon.mybeauty.domain.article.application.CommentApplicationService;
@@ -16,7 +17,6 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
@@ -24,11 +24,9 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -61,24 +59,6 @@ public class CommentControllerTest extends CommonControllerTest {
                 .content(new ObjectMapper().writeValueAsString(requestDto)))
                 .andDo(print());
 
-        // then
-//        result.andExpect(status().isOk())
-//                .andExpect(jsonPath("$.isSuccess").value(true))
-//                .andExpect(jsonPath("$.result").value(expectedCommentId))
-//                .andDo(document("comment-create",    // 문서 식별자
-//                        preprocessRequest(prettyPrint()),    // 요청 데이터 보기 좋게 출력
-//                        preprocessResponse(prettyPrint()),    // 응답 데이터 보기 좋게 출력
-//                        requestHeaders(    // 요청 헤더 문서화
-//                                headerWithName("Authorization").description("사용자 인증 및 인가를 위한 Bearer token")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("isSuccess").description("API 성공 여부"),
-//                                fieldWithPath("responseCode").description("응답 코드"),
-//                                fieldWithPath("responseMessage").description("응답 메시지"),
-//                                fieldWithPath("result").description("요청 결과 생성된 댓글 ID")
-//                        )
-//                ));
-
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.result").value(expectedCommentId))
@@ -95,12 +75,14 @@ public class CommentControllerTest extends CommonControllerTest {
                                         .requestHeaders(
                                                 headerWithName("Authorization").description("Bearer 토큰 (예: `Bearer your-jwt-token`)")
                                         )
+                                        .responseSchema(Schema.schema("BaseResponseSchema"))
                                         .responseFields(
-                                            fieldWithPath("isSuccess").description("API 성공 여부"),
-                                            fieldWithPath("responseCode").description("응답 코드"),
-                                            fieldWithPath("responseMessage").description("응답 메시지"),
-                                            fieldWithPath("result").description("요청 결과 생성된 댓글 ID")
-                                        ).build()
+                                                fieldWithPath("isSuccess").description("API 성공 여부"),
+                                                fieldWithPath("responseCode").description("응답 코드"),
+                                                fieldWithPath("responseMessage").description("응답 메시지"),
+                                                fieldWithPath("result").description("요청 결과 생성된 댓글 ID")
+                                        )
+                                        .build()
                         )
                 ));
     }

--- a/src/test/java/me/jooeon/mybeauty/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/me/jooeon/mybeauty/domain/review/application/ReviewServiceTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "secret"})
 @SpringBootTest
 public class ReviewServiceTest {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,5 +34,7 @@ spring:
         default_batch_fetch_size: 100
         dialect: org.hibernate.dialect.MySQLDialect
 
+    defer-datasource-initialization: true
+
 app:
   baseUrl: http://localhost:8080


### PR DESCRIPTION
* Spring Rest Docs 기반으로 생성된 문서 OpenAPI3 스팩으로 변경
* OpenAPI3 스팩 도입에 따른 Comment Test 코드 변경
* Build 시 API 문서 생성 자동화를 위한 Gradle task 추가